### PR TITLE
Changed manual login event handler to handle .anon user

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -18,7 +18,7 @@ class RegistrationController extends BaseController
         
         if ($return instanceof RedirectResponse) {
             $user = $this->container->get('security.context')->getToken()->getUser();            
-            if ( $user ) {
+            if ( is_object($user) ) {
                 $dispatcher = $this->container->get('event_dispatcher');
                 $event = new ManualLoginEvent($user);
                 $dispatcher->dispatch('security.manual_login', $event);

--- a/Manager/UserDiscriminator.php
+++ b/Manager/UserDiscriminator.php
@@ -66,10 +66,7 @@ class UserDiscriminator
     public function onSecurityManualLogin(ManualLoginEvent $event)
     {
         $user = $event->getUser();
-        if (is_object($user)) {
-            $this->setClass(get_class($user), true);
-        }
-        
+        $this->setClass(get_class($user), true);
     }
     
     /**

--- a/Manager/UserDiscriminator.php
+++ b/Manager/UserDiscriminator.php
@@ -66,7 +66,10 @@ class UserDiscriminator
     public function onSecurityManualLogin(ManualLoginEvent $event)
     {
         $user = $event->getUser();
-        $this->setClass(get_class($user), true);
+        if (is_object($user)) {
+            $this->setClass(get_class($user), true);
+        }
+        
     }
     
     /**


### PR DESCRIPTION
When set disabled confirmation $event->getUser() in onSecurityManualLogin returned .anon,
which threw exception. That small change prevents that.
